### PR TITLE
RHIN-4914: adds Kick_Admin_Hang_up message Android

### DIFF
--- a/uxkit/src/main/java/com/voxeet/uxkit/implementation/VoxeetActionBarView.java
+++ b/uxkit/src/main/java/com/voxeet/uxkit/implementation/VoxeetActionBarView.java
@@ -376,6 +376,14 @@ public class VoxeetActionBarView extends VoxeetView {
         hangup.setOnClickListener(v1 -> {
             VoxeetSDK.audio().playSoundType(AudioType.HANGUP);
 
+            // kick other participants out of conference
+            String conferenceId = VoxeetSDK.conference().getConferenceId();
+            if (null != conferenceId) {
+                VoxeetSDK.command().send(conferenceId, "Kick_Admin_Hang_up")
+                .then(result -> {
+                }).error(Throwable::printStackTrace);
+            }
+            
             VoxeetSDK.conference().leave()
                     .then(aBoolean -> {
                         //manage the result ?


### PR DESCRIPTION
**Related Jira link:** https://rhinogram.atlassian.net/browse/RHIN-4914

### Fix Version
* 3.5.3

### PR Checklist
- [X] I've tested in all browsers (IE11, Firefox, Safari, Chrome, and iOS)
- [X] I have added any new environment variables to the SSM Parameter Store

### What should this PR do?
* adds Kick_Admin_Hang_up message to kick other users out of conference when member who started conference leaves
